### PR TITLE
use the llvm-nm variable.

### DIFF
--- a/tests/test_tsan.c
+++ b/tests/test_tsan.c
@@ -2,7 +2,7 @@
 //
 // REQUIRES: clang, llvm-nm
 // RUN: %clang -o %t -fsanitize=thread -g -O1 %s
-// RUN: llvm-nm %t | grep __tsan
+// RUN: %llvm-nm %t | grep __tsan
 // RUN: env TSAN_OPTIONS="log_path=stdout:exitcode=0"  %t 2>&1 > %t.out
 // RUN: grep -q "data race" %t.out
 


### PR DESCRIPTION
Otherwise, fails with
```

******************** TEST 'LLVM regression suite :: test_tsan.c' FAILED ********************
Script:
--
: 'RUN: at line 4';   /usr/bin/clang-10 -o /tmp/autopkgtest.dBlNiz/autopkgtest_tmp/build/tests/Output/test_tsan.c.tmp -fsanitize=thread -g -O1 /tmp/autopkgtest.dBlNiz/autopkgtest_tmp/tests/test_tsan.c
: 'RUN: at line 5';   llvm-nm /tmp/autopkgtest.dBlNiz/autopkgtest_tmp/build/tests/Output/test_tsan.c.tmp | grep __tsan
: 'RUN: at line 6';   env TSAN_OPTIONS="log_path=stdout:exitcode=0"  /tmp/autopkgtest.dBlNiz/autopkgtest_tmp/build/tests/Output/test_tsan.c.tmp 2>&1 > /tmp/autopkgtest.dBlNiz/autopkgtest_tmp/build/tests/Output/test_tsan.c.tmp.out
: 'RUN: at line 7';   grep -q "data race" /tmp/autopkgtest.dBlNiz/autopkgtest_tmp/build/tests/Output/test_tsan.c.tmp.out
--
Exit Code: 1

Command Output (stderr):
--
/tmp/autopkgtest.dBlNiz/autopkgtest_tmp/build/tests/Output/test_tsan.c.script: line 2: llvm-nm: command not found

--
```