### PR TITLE
rpass_inline.cpp: update of the tests for clang 13

### DIFF
--- a/tests/rpass_inline.cpp
+++ b/tests/rpass_inline.cpp
@@ -7,3 +7,11 @@
 int foo(int x, int y) __attribute__((always_inline));
 int foo(int x, int y) { return x + y; }
 int bar(int j) { return foo(j, j - 2); }
+
+int sum = 0;
+
+int main(int argc, const char *argv[]) {
+  for (int i = 0; i < 30; i++)
+    bar(argc);
+  return sum;
+}


### PR DESCRIPTION
With clang 13, the previous tests didn't trigger anything.
With the full test, it is now back.

Probably caused by
https://reviews.llvm.org/D94825
or
https://reviews.llvm.org/D94333