### PR TITLE
Verify that the optim result file is correctly generated

### DIFF
--- a/tests/save-optimization-record.c
+++ b/tests/save-optimization-record.c
@@ -3,12 +3,11 @@
 // doesn't happen again
 //
 // RUN: mkdir -p %t/test && cd %t/test
-// RUN: %clang -S -fsave-optimization-record -emit-llvm %s -o save-optimization-record.c.opt
+// RUN: %clang -S -O2 -fsave-optimization-record -emit-llvm %s -o save-optimization-record.c.opt
 // RUN: test -s save-optimization-record.c.opt.yaml
 // REQUIRES: clang
 
 // marking it as failing util the bug is addressed
-// XFAIL: *
 
 #define N 1536
 float A[N][N];


### PR DESCRIPTION
It regressed in 13:
https://bugs.llvm.org/show_bug.cgi?id=51642