### PR TITLE
libc++_link_static.cpp: remove the grep quiet option

### DIFF
--- a/tests/libc++_link_static.cpp
+++ b/tests/libc++_link_static.cpp
@@ -4,7 +4,7 @@
 // Check linking with libstdc++
 // RUN: %clangxx -o %t %s -fPIC -pie -static-libstdc++
 // RUN: %t
-// RUN: ldd %t 2>&1|grep -qv libstdc++
+// RUN: ldd %t 2>&1|grep -v libstdc++
 //
 // Check linking with libc++. As of now, this fails:
 // FAIL: %clangxx -o %t -fPIC %s -pie -stdlib=libc++ -static-libstdc++


### PR DESCRIPTION
To help with the debug of #71