### PR TITLE
Add host architecture to the available features

### DIFF
--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -7,6 +7,8 @@ config.suffixes = ['.ll', '.c', '.cpp', '.test', '.txt', '.s', '.mir', '.mlir']
 config.test_source_root = os.path.join("@CMAKE_CURRENT_SOURCE_DIR@", "tests")
 config.excludes = ['Inputs']
 
+config.available_features.add("@CMAKE_HOST_SYSTEM_PROCESSOR@")
+
 def enable_feature(name, option):
     if option.lower() in ('on', 1):
         config.available_features.add(name)

--- a/tests/lto_and_cfi.c
+++ b/tests/lto_and_cfi.c
@@ -1,5 +1,6 @@
 // Test compatibility between lto and CFI, see  https://bugzilla.redhat.com/show_bug.cgi?id=1794936
 // RUN: %clang -flto -fsanitize=cfi -fvisibility=hidden %s -o %t
+// XFAIL: s390x, ppc64le
 
 int main() {
   return 0;


### PR DESCRIPTION
So that we can XFAIL on these architectures, as done for tests/lto_and_cfi.c