### PR TITLE
Make it possible to manually disable OpenMP tests

### DIFF
--- a/tests/basic_openmp.c
+++ b/tests/basic_openmp.c
@@ -3,6 +3,7 @@
 // RUN: %clang -fopenmp %s -o %t
 // RUN: %t | grep "Num Threads: 1"
 // REQUIRES: clang
+// XFAIL: s390x
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
LLVM openmp is not supported upstream on s390x, it's good to be able to
configure the testsuite accordingly.