### PR TITLE
cmake: Use proper error message type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(LLVMToolchainIntegrationTestSuite VERSION 1.0 LANGUAGES NONE)
 message(STATUS "Checking for lit")
 find_program(LIT lit)
 if(NOT LIT)
-    message(ERROR "lit program not found")
+    message(FATAL_ERROR "lit program not found")
 endif()
 
 macro(find_program_or_warn OUT_VAR name)


### PR DESCRIPTION
"ERROR" is not a valid message type in CMake.

The error message currently gets printed as:

```
-- Checking for lit
ERRORlit program not found
-- Checking for clang++
-- Disabling tests related to clang++
-- Checking for clang
-- Disabling tests related to clang
-- Checking for clang-tidy
-- Disabling tests related to clang-tidy
-- Checking for clang-format
-- Disabling tests related to clang-format
-- Checking for clang-format-diff
-- Disabling tests related to clang-format-diff
-- Checking for clangd
-- Disabling tests related to clangd
-- Checking for opt
-- Checking for llvm-nm
-- Checking for llc
(etc)
```

I _think_ `FATAL_ERROR` is the correct one to use, unless you want to continue generation, in which case `SEND_ERROR` should be used. See https://cmake.org/cmake/help/v3.0/command/message.html