### PR TITLE
Explicilty disable lldb tests on ppc64

### DIFF
--- a/tests/basic_lldb.c
+++ b/tests/basic_lldb.c
@@ -1,6 +1,7 @@
 // RUN: %clang -g -o %t %s
 // RUN: %lldb -s %S/basic_lldb.in %t | grep "main at basic_lldb.c:"
 // REQUIRES: lldb, clang
+// XFAIL: ppc64
 
 int main() {
 	int a=0;

--- a/tests/basic_lldb2.cpp
+++ b/tests/basic_lldb2.cpp
@@ -1,6 +1,7 @@
 // RUN: %clangxx -g -o %t %s
 // RUN: %lldb -s %S/basic_lldb2.in %t | grep "stop reason = step over"
 // REQUIRES: lldb, clangxx
+// XFAIL: ppc64
 
 #include <vector>
 int main (void)


### PR DESCRIPTION
Upstream doesn't support  setting breakpoint on ppc64