### PR TITLE
Remove lld requirement from thinlto test

### DIFF
--- a/tests/thinlto.c
+++ b/tests/thinlto.c
@@ -1,5 +1,5 @@
 // verify that thinlto is available
-// REQUIRES: clang, lld
+// REQUIRES: clang
 // RUN: %clang -flto=thin -O2 %S/Inputs/foo.c %s -o %t
 // RUN: %t
 


### PR DESCRIPTION
lld is not really needed here. However, having it listed makes the test unable to run in systems without lld support.
I've tested this in an s390x platform (no lld) and the test now runs and passes.