### PR TITLE
libclang_cpp: Make the test more robust.

### DIFF
--- a/tests/libclang_cpp.cpp
+++ b/tests/libclang_cpp.cpp
@@ -2,7 +2,8 @@
 //
 // REQUIRES: clang, llvm-config
 // RUN: %clangxx -lclang-cpp -v %s -o %t `%llvm-config --cxxflags --ldflags --libs`
-// RUN: ldd %t 2>&1|grep -q libclang-cpp
+// RUN: ldd %t 2>&1 > %t.lddoutput
+// RUN: grep -q libclang-cpp %t.lddoutput
 
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "llvm/Support/CommandLine.h"


### PR DESCRIPTION
Piping ldd's output into grep can fail randomly, likely due to buffering issues, and causing false positives. Redirect the output to a file instead to force flushing, and grep from the file.