### PR TITLE
Enable libc++ static linking test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,9 +54,12 @@ jobs:
          export PATH=$PATH:/usr/share/clang/scan-build-py-${{ matrix.version }}/bin/:/usr/lib/llvm-${{ matrix.version }}/libexec
          mkdir build && cd build
          LIBUNWIND_ENABLED=ON
+         STATIC_LIBCXX_ENABLED=ON
          if test ${{ matrix.version }} -lt 12; then
             # Libunwind has been packaged only from 12
             LIBUNWIND_ENABLED=OFF
+            # libc++.a did not link libc++abi.a on old versions
+            STATIC_LIBCXX_ENABLED=OFF
          fi
          cmake -DLIT=/usr/lib/llvm-${{ matrix.version }}/build/utils/lit/lit.py \
            -DCLANG_BINARY=/usr/bin/clang-${{ matrix.version }} \
@@ -82,6 +85,7 @@ jobs:
            -DLLVMPROFDATA=/usr/bin/llvm-profdata-${{ matrix.version }} \
            -DENABLE_COMPILER_RT=ON \
            -DENABLE_LIBCXX=ON \
+           -DENABLE_STATIC_LIBCXX=$STATIC_LIBCXX_ENABLED \
            -DENABLE_LIBUNWIND=$LIBUNWIND_ENABLED \
            ../
          # debug the output

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -16,7 +16,8 @@ jobs:
         run: |
             sudo dnf install -y llvm-devel clang-devel cmake make python3-lit \
                  lld clang-tools-extra gcc gcc-c++ libcxx-devel compiler-rt libstdc++-devel \
-                 glibc-static libstdc++-static mlir mlir-devel llvm-libunwind llvm-libunwind-devel
+                 glibc-static libcxx-static libstdc++-static mlir mlir-devel \
+                 llvm-libunwind llvm-libunwind-devel
       - name: Run the testsuite
         run: |
          mkdir build && cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ find_program_or_warn(MLIRTRANSLATE mlir-translate)
 
 option(ENABLE_COMPILER_RT "assume compiler-rt is available" ON)
 option(ENABLE_LIBCXX "assume libc++ is available" ON)
+option(ENABLE_STATIC_LIBCXX "assume libc++.a is available" ON)
 option(ENABLE_LIBUNWIND "assume libunwind is available" ON)
 
 configure_file(

--- a/tests/libc++_link_static.cpp
+++ b/tests/libc++_link_static.cpp
@@ -7,7 +7,7 @@
 // RUN: ldd %t 2>&1|grep -v libstdc++
 //
 // Check static linking with libc++
-// RUN: %clangxx -o %t -fPIC %s -pie -stdlib=libc++ -static-libstdc++
+// RUN: %clangxx -o %t -fPIC %s -pie -stdlib=libc++ -static-libstdc++ -pthread
 //
 // REQUIRES: clangxx, libc++
 

--- a/tests/libc++_link_static.cpp
+++ b/tests/libc++_link_static.cpp
@@ -6,8 +6,8 @@
 // RUN: %t
 // RUN: ldd %t 2>&1|grep -v libstdc++
 //
-// Check static linking with libc++. As of now, this fails:
-// FAIL: %clangxx -o %t -fPIC %s -pie -stdlib=libc++ -static-libstdc++
+// Check static linking with libc++
+// RUN: %clangxx -o %t -fPIC %s -pie -stdlib=libc++ -static-libstdc++
 //
 // REQUIRES: clangxx, libc++
 

--- a/tests/libc++_link_static.cpp
+++ b/tests/libc++_link_static.cpp
@@ -9,7 +9,7 @@
 // Check static linking with libc++
 // RUN: %clangxx -o %t -fPIC %s -pie -stdlib=libc++ -static-libstdc++ -pthread
 //
-// REQUIRES: clangxx, libc++
+// REQUIRES: clangxx, static-libc++
 
 #include <iostream>
 int main () {

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -47,4 +47,5 @@ config.substitutions.append(('%cmake', '@CMAKE_COMMAND@'))
 
 enable_feature("compiler-rt", "@ENABLE_COMPILER_RT@")
 enable_feature("libc++", "@ENABLE_LIBCXX@")
+enable_feature("static-libc++", "@ENABLE_STATIC_LIBCXX@")
 enable_feature("libunwind", "@ENABLE_LIBUNWIND@")


### PR DESCRIPTION
Would be nice to have this test. This regressed in LLVM 15 and required some ugly workarounds -- thankfully we had a separate clang integration test to catch it.