### PR TITLE
Improve Fedora coverage in github actions:

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -5,21 +5,26 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
+      matrix:
+        fedora-version: [37, rawhide]
     container:
-      image: "fedora:37"
+      image: "fedora:${{matrix.fedora-version}}"
+      # These options are required to be able to run lldb inside the container
+      options: "--cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies
         run: |
-            sudo dnf install -y llvm-devel clang-devel cmake make python3-lit \
-                 lld clang-tools-extra gcc gcc-c++ libcxx-devel compiler-rt libstdc++-devel \
-                 glibc-static libcxx-static libstdc++-static mlir mlir-devel \
-                 llvm-libunwind llvm-libunwind-devel
+          sudo dnf install -y llvm-devel clang-devel cmake make python3-lit \
+                lld lldb clang-analyzer clang-tools-extra gcc gcc-c++ \
+                libcxx-devel compiler-rt libstdc++-devel \
+                glibc-static libcxx-static libstdc++-static mlir mlir-devel \
+                llvm-libunwind llvm-libunwind-devel
       - name: Run the testsuite
         run: |
-         mkdir build && cd build
-         cmake .. -DENABLE_COMPILER_RT=ON -DENABLE_LIBCXX=ON
-         cmake --build . --target check -v
+          mkdir build && cd build
+          cmake ..
+          cmake --build . --target check -v


### PR DESCRIPTION
* Extended Fedora jobs to run on Fedora 37 and rawhide.
* lldb, scan-build, scan-view and scan-build-py tests were skipped due to missing packages - fixed.
* Run in ubuntu-20.04 to avoid potential breakages after Ubuntu updates.
* Add capabilities to the container to be able to run lldb tests