### PR TITLE
lto_and_cross_dso_cfi: cleanup temp dir to avoid false positives when rerunning the testsuite

### DIFF
--- a/tests/lto_and_cross_dso_cfi.c
+++ b/tests/lto_and_cross_dso_cfi.c
@@ -1,4 +1,5 @@
 // Test compatibility between lto and CFI with cross -dso enabled
+// RUN: rm -rf %t.dir
 // RUN: mkdir %t.dir
 // RUN: %clang -UMAIN -flto -fsanitize=cfi -fsanitize-cfi-cross-dso -fvisibility=default -fuse-ld=lld %s -shared -o %t.dir/liblocalcrossdso.so
 // RUN: %clang -DMAIN -flto -fsanitize=cfi -fsanitize-cfi-cross-dso -fvisibility=default -fuse-ld=lld %s -o %t -L%t.dir -llocalcrossdso


### PR DESCRIPTION
Fixes lto_and_cross_dso_cfi failures in reruns due to mkdir being unable to create an existing %t.dir.