### PR TITLE
Add a test for hardware-assisted address sanitizer.

### DIFF
--- a/tests/test_hwasan.c
+++ b/tests/test_hwasan.c
@@ -1,0 +1,15 @@
+// Test hwasan use after free -- aarch64 only.
+//
+// REQUIRES: clang, compiler-rt, aarch64
+// RUN: %clang -o %t -fsanitize=hwaddress -g %s
+// RUN: env HWASAN_OPTIONS="log_path=stdout:exitcode=0"  %t 2>&1 > %t.out
+// RUN: grep -q "HWAddressSanitizer: tag-mismatch" %t.out
+// RUN: grep -q "Cause: use-after-free" %t.out
+
+#include <stdlib.h>
+
+int main() {
+  int *p = malloc(sizeof(int));
+  free(p); // The memory is leaked here.
+  return *p;
+}


### PR DESCRIPTION
This commit adds a simple use-after-free testcase to be tested with -fsanitize=hwaddress. aarch64 only.