### PR TITLE
S390x compatibility fixes

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fedora-version: [37, rawhide]
+        fedora-version: [38, 39, rawhide]
     container:
       image: "fedora:${{matrix.fedora-version}}"
       # These options are required to be able to run lldb inside the container

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
 cmake_minimum_required(VERSION 3.4.3)
-project(LLVMToolchainIntegrationTestSuite VERSION 1.0 LANGUAGES NONE)
-
-enable_language(C)
-enable_language(CXX)
 
 message(STATUS "Checking for lit")
 find_program(LIT lit)
@@ -15,6 +11,16 @@ macro(find_program_or_warn OUT_VAR name)
     find_program(${OUT_VAR} ${name})
     if (NOT ${OUT_VAR})
         message(STATUS "Disabling tests related to ${name}")
+    endif()
+endmacro()
+
+macro(find_library_or_warn OUT_VAR name)
+    cmake_parse_arguments(MY_FIND "" "" "HINTS" ${ARGN} )
+
+    message(STATUS "Checking for ${name}")
+    find_library(${OUT_VAR} ${name} HINTS ${MY_FIND_HINTS})
+    if (NOT ${OUT_VAR})
+        message(WARNING "${name} not found. Disabling tests related to ${name}")
     endif()
 endmacro()
 
@@ -39,11 +45,23 @@ find_program_or_warn(SCANVIEW scan-view)
 find_program_or_warn(SCANBUILDPY scan-build-py)
 find_program_or_warn(MLIRTRANSLATE mlir-translate)
 
+set(CMAKE_C_COMPILER ${CLANG_BINARY})
+set(CMAKE_CXX_COMPILER ${CLANGXX_BINARY})
+
+project(LLVMToolchainIntegrationTestSuite VERSION 1.0 LANGUAGES NONE)
+
+enable_language(C)
+enable_language(CXX)
 
 option(ENABLE_COMPILER_RT "assume compiler-rt is available" ON)
 option(ENABLE_LIBCXX "assume libc++ is available" ON)
 option(ENABLE_STATIC_LIBCXX "assume libc++.a is available" ON)
 option(ENABLE_LIBUNWIND "assume libunwind is available" ON)
+
+# Detect if libomp is supported. Ubuntu stores the symlink library under a
+# version-dependent directory so we need to provide a hint to CMake to find it.
+string(REGEX MATCH "^[0-9]+" LLVM_MAJOR ${CMAKE_C_COMPILER_VERSION})
+find_library_or_warn(LIBOMP libomp.so HINTS /usr/lib/llvm-${LLVM_MAJOR}/lib/)
 
 message(STATUS "Checking kernel support for tagged address ABI")
 try_run(

--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,11 @@ Sensible configuration variables
 
 - ``ENABLE_COMPILER_RT``: ON (the default) if we assume compiler-rt is available
 - ``ENABLE_LIBCXX``: ON (the default) if we assume libc++ is available
-- ``ENABLE_UNWIND``: ON (the default) if we assume libunwind is available
+- ``ENABLE_STATIC_LIBCXX``: ON (the default) if we assume libc++.a is available
+- ``ENABLE_LIBUNWIND``: ON (the default) if we assume libunwind is available
 - ``ENABLE_HWASAN``: Run hwasan tests. Autodetected based on the host system.
+- ``ENABLE_LIBOMP``: Run libomp tests. Autodetected based on the system. It can
+    be manually forced via `-DENABLE_LIBOMP=<ON|OFF>` at cmake configure time
 
 Writing new tests
 -----------------

--- a/tests/basic_openmp.c
+++ b/tests/basic_openmp.c
@@ -2,8 +2,7 @@
 //
 // RUN: %clang -fopenmp %s -o %t
 // RUN: %t | grep "Num Threads: 1"
-// REQUIRES: clang
-// XFAIL: s390x
+// REQUIRES: clang, libomp
 
 #include <omp.h>
 #include <stdio.h>

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -18,6 +18,9 @@ def enable_program(name, binary):
         config.available_features.add(name)
         config.substitutions.append(('%'+name, binary))
 
+def enable_library(name, library):
+    if os.path.exists(library):
+        config.available_features.add(name)
 
 # The order matters, e.g. substitution for clang-format-diff
 # must appear before clang-format, because the latter is a prefix of the former.
@@ -44,6 +47,8 @@ enable_program('scan-build', "@SCANBUILD@")
 enable_program('scan-view', "@SCANVIEW@")
 enable_program('opt', "@OPT_BINARY@")
 enable_program('mlir-translate', "@MLIRTRANSLATE@")
+
+enable_library('libomp', "@LIBOMP@")
 
 config.substitutions.append(('%cmake', '@CMAKE_COMMAND@'))
 

--- a/tests/openmp_headers.c
+++ b/tests/openmp_headers.c
@@ -1,8 +1,7 @@
 // Test OpenMP headers install
 //
 // RUN: %clang -fopenmp -E %s -o %t
-// REQUIRES: clang
-// XFAIL: s390x
+// REQUIRES: clang, libomp
 
 #include <omp.h>
 #if _OPENMP >= 201811

--- a/tests/openmp_tools.c
+++ b/tests/openmp_tools.c
@@ -2,8 +2,7 @@
 // RUN: %clang -fopenmp -DTOOLS %s -shared -o %t_Tools.so
 // RUN: %clang -fopenmp -UTOOLS %s -o %t
 // RUN: OMP_TOOL_LIBRARIES=%t_Tools.so %t | grep "INIT"
-// REQUIRES: clang
-// XFAIL: s390x
+// REQUIRES: clang, libomp
 #ifdef TOOLS
 
 // OpenMP Tools are only supported starting OpenMP 5

--- a/tests/whole-toolchain.c
+++ b/tests/whole-toolchain.c
@@ -2,6 +2,8 @@
 // REQUIRES: clang, lld, compiler-rt
 // RUN: %clang -fuse-ld=lld -rtlib=compiler-rt %s -o %t
 // RUN: %t | grep "Hello World"
+// s390x now runs but fails because it does not support compiler-rt builtins.
+// XFAIL: s390x
 
 #include<stdio.h>
 int main(int argc, char **argv) {

--- a/tests/whole-toolchain.cpp
+++ b/tests/whole-toolchain.cpp
@@ -5,6 +5,8 @@
 // alternative would be to force usage of LLVM unwinder when building compiler-rt.
 // RUN: %clangxx -fuse-ld=lld -rtlib=compiler-rt -stdlib=libc++ -lgcc_eh %s -o %t
 // RUN: %t | grep "Hello World"
+// s390x now runs but fails because it does not support compiler-rt builtins.
+// XFAIL: s390x
 
 #include <iostream>
 int main(int argc, char **argv) {


### PR DESCRIPTION
With the new support  (LLVM-18) for libomp and lld in s390x there are now tests that are unexpectedly passing (marked as failure), others that are not being run. The summary of changes in this PR is as follows:

* LIBOMP presence is detected at cmake configuration step similarly to how all the binaries are detected, using cmake's `find_library`.
*  `libomp` feature added in lit.site.cfg. This is enabled depending on LIBOMP provided from cmake configuration.
* libomp related tests are now have `REQUIRES: libomp` lit directive. These tests will now be marked UNSUPPORTED in s390x/LLVM < 18, and will run normally on LLVM >= 18
* whole-toolchain testcases now run on s390x due to `lld` being supported. These tests are expected to fail, as building with  `-rtlib=compiler-rt`  will fail due to unsupported `builtins` library in the arch. Added XFAIL: s390x on them.

Additionally, fedora workflow in GH actions has been updated with latest supported versions.