### PR TITLE
Make sure that libc++ and asan work correctly can be caused by -Bsymbolic-functions

### DIFF
--- a/tests/test_asan_libc++.cpp
+++ b/tests/test_asan_libc++.cpp
@@ -1,0 +1,14 @@
+// Make sure that libc++ and asan work correctly
+// can be caused by -Bsymbolic-functions
+// https://github.com/llvm/llvm-project/issues/59432
+// RUN: %clangxx -xc++ - -stdlib=libc++ -fsanitize=address %s -o %t
+// RUN: %t
+// REQUIRES: clang, compiler-rt, libc++
+//
+
+#include <stdexcept>
+int main() {
+#if CLANG_MAJOR > 18
+    std::logic_error("");
+#endif
+}


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/issues/59432