### PR TITLE
Don't run scheduled CI in forks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'opencollab/llvm-toolchain-integration-test-suite'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
I don't think we want this to run nightly on every fork of the repo...