### PR TITLE
Fix hello.mlir test on non-released LLVM

### DIFF
--- a/tests/hello.mlir
+++ b/tests/hello.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: clang, mlir-translate, llvm-config
-// RUN: if `%llvm-config --version | grep -q 14`; then sed 's/func.func/func/' %s; else cat %s; fi | %mlir-translate --mlir-to-cpp > %t.c
+// RUN: if `%llvm-config --version | grep -qE '^14\.'`; then sed 's/func.func/func/' %s; else cat %s; fi | %mlir-translate --mlir-to-cpp > %t.c
 // RUN: %clang %t.c -o %t
 // RUN: %t
 


### PR DESCRIPTION
Ensure the test is executed only if the major version is 14. When using unreleased versions, more information may be appended to the version string, e.g. 21.0.0pre20250214.g1ff5f328d98246.

This also prevents false-positives for the following versions: x.y.14 and 140.y.z.