### PR TITLE
Bump cmake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.5.0)
 
 message(STATUS "Checking for lit")
 find_program(LIT lit)

--- a/tests/minimal_llvm_cmake.txt
+++ b/tests/minimal_llvm_cmake.txt
@@ -4,7 +4,7 @@
 # RUN: cat %s > %t/CMakeLists.txt
 # RUN: cd %t/_build && %cmake ..
 
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.5.0)
 
 find_package(LLVM)
 

--- a/tests/plugins_newpm.txt
+++ b/tests/plugins_newpm.txt
@@ -11,7 +11,7 @@
 # RUN: grep "Function name: foo" %t.output
 # REQUIRES: opt, clang
 
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(TestLLVMPass)
 find_package(LLVM REQUIRED CONFIG)


### PR DESCRIPTION
CMake 4.0 no longer supports compatibility with CMake < 3.5. Bump the required versions accordingly.

https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features