### PR TITLE
Dynamically check if compiler-rt has all built-ins on s390x

### DIFF
--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -1,5 +1,7 @@
 import os
 import lit
+import re
+import subprocess
 
 config.name = 'LLVM regression suite'
 config.test_format = lit.formats.ShTest(True)
@@ -57,3 +59,15 @@ enable_feature("libc++", "@ENABLE_LIBCXX@")
 enable_feature("static-libc++", "@ENABLE_STATIC_LIBCXX@")
 enable_feature("libunwind", "@ENABLE_LIBUNWIND@")
 enable_feature("support_hwasan", "@ENABLE_HWASAN@")
+
+def getLLVMMajorVersion():
+    out = subprocess.run(["llvm-config", "--version"], capture_output=True)
+    m = re.match(r'^([0-9]+).', out.stdout.decode('utf-8'))
+    if m:
+        return int(m.group(1))
+    else:
+        raise BaseException("Could not parse LLVM version"
+                            + out.stdout.decode('utf-8'))
+
+if "s390x" == "@CMAKE_HOST_SYSTEM_PROCESSOR@" and getLLVMMajorVersion() < 21:
+   config.available_features.add("availability-compiler-rt-builtins-missing")

--- a/tests/whole-toolchain.c
+++ b/tests/whole-toolchain.c
@@ -2,8 +2,7 @@
 // REQUIRES: clang, lld, compiler-rt
 // RUN: %clang -fuse-ld=lld -rtlib=compiler-rt %s -o %t
 // RUN: %t | grep "Hello World"
-// s390x now runs but fails because it does not support compiler-rt builtins.
-// XFAIL: s390x
+// XFAIL: availability-compiler-rt-builtins-missing
 
 #include<stdio.h>
 int main(int argc, char **argv) {

--- a/tests/whole-toolchain.cpp
+++ b/tests/whole-toolchain.cpp
@@ -5,8 +5,7 @@
 // alternative would be to force usage of LLVM unwinder when building compiler-rt.
 // RUN: %clangxx -fuse-ld=lld -rtlib=compiler-rt -stdlib=libc++ -lgcc_eh %s -o %t
 // RUN: %t | grep "Hello World"
-// s390x now runs but fails because it does not support compiler-rt builtins.
-// XFAIL: s390x
+// XFAIL: availability-compiler-rt-builtins-missing
 
 #include <iostream>
 int main(int argc, char **argv) {


### PR DESCRIPTION
Starting with commit 6d03f51f0c591, compiler-rt now has all the built-ins required in order to successfully run a hello world on s390x. That means, whole-toolchain.c and whole-toolchain.cpp do succeed when LLVM 21 or greater is used.