### PR TITLE
Add missing -fPIC flag

### DIFF
--- a/tests/openmp_tools.c
+++ b/tests/openmp_tools.c
@@ -1,5 +1,5 @@
 // Test OpenMP Tools support
-// RUN: %clang -fopenmp -DTOOLS %s -shared -o %t_Tools.so
+// RUN: %clang -fopenmp -DTOOLS %s -fPIC -shared -o %t_Tools.so
 // RUN: %clang -fopenmp -UTOOLS %s -o %t
 // RUN: OMP_TOOL_LIBRARIES=%t_Tools.so %t | grep "INIT"
 // REQUIRES: clang, libomp


### PR DESCRIPTION
We're linking with `-shared`, so the compilation needs to use `-fPIC`.

We were getting away with this thanks to text relocations, but recent Fedora rawhide defaults to use `-z notext`.