### PR TITLE
Added clang-doc test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,6 +77,7 @@ jobs:
          cmake -DLIT="$LIT" \
            -DCLANG_BINARY=/usr/bin/clang-${{ matrix.version }} \
            -DCLANGXX_BINARY=/usr/bin/clang++-${{ matrix.version }} \
+           -DCLANG_DOC_BINARY=/usr/bin/clang-doc-${{ matrix.version }} \
            -DCLANG_TIDY_BINARY=/usr/bin/clang-tidy-${{ matrix.version }} \
            -DCLANG_FORMAT_BINARY=/usr/bin/clang-format-${{ matrix.version }} \
            -DCLANG_FORMAT_DIFF_BINARY=/usr/bin/clang-format-diff-${{ matrix.version }} \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,6 +77,7 @@ jobs:
          cmake -DLIT="$LIT" \
            -DCLANG_BINARY=/usr/bin/clang-${{ matrix.version }} \
            -DCLANGXX_BINARY=/usr/bin/clang++-${{ matrix.version }} \
+           -DFILECHECK_BINARY=/usr/bin/FileCheck-${{ matrix.version }} \
            -DCLANG_DOC_BINARY=/usr/bin/clang-doc-${{ matrix.version }} \
            -DCLANG_TIDY_BINARY=/usr/bin/clang-tidy-${{ matrix.version }} \
            -DCLANG_FORMAT_BINARY=/usr/bin/clang-format-${{ matrix.version }} \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ endmacro()
 
 find_program_or_warn(CLANGXX_BINARY clang++)
 find_program_or_warn(CLANG_BINARY clang)
+find_program_or_warn(CLANG_DOC_BINARY clang-doc)
 find_program_or_warn(CLANG_TIDY_BINARY clang-tidy)
 find_program_or_warn(CLANG_FORMAT_BINARY clang-format)
 find_program_or_warn(CLANG_FORMAT_DIFF_BINARY clang-format-diff)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ macro(find_library_or_warn OUT_VAR name)
     endif()
 endmacro()
 
+find_program_or_warn(FILECHECK_BINARY FileCheck)
 find_program_or_warn(CLANGXX_BINARY clang++)
 find_program_or_warn(CLANG_BINARY clang)
 find_program_or_warn(CLANG_DOC_BINARY clang-doc)

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,7 @@ Sensible configuration variables
 
 - ``CLANG_BINARY``: path to the clang binary to check
 - ``CLANGXX_BINARY``: path to the clang++ binary to check
+- ``CLANG_DOC_BINARY``: path to the clang doc binary to check
 - ``CLANG_TIDY_BINARY``: path to the clang tidy binary to check
 - ``LLD_BINARY``: path to the lld binary to check
 - ``LLDB_BINARY``: path to the lldb binary to check
@@ -56,6 +57,7 @@ Lit substitutions
 
     - ``%clang``
     - ``%clangxx``
+    - ``%clang-doc``
     - ``%clang-tidy``
     - ``%lldb``
     - ``%lld``

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,7 @@ Sensible configuration variables
 - ``CLANGXX_BINARY``: path to the clang++ binary to check
 - ``CLANG_DOC_BINARY``: path to the clang doc binary to check
 - ``CLANG_TIDY_BINARY``: path to the clang tidy binary to check
+- ``FILECHECK_BINARY``: path to the FileCheck program
 - ``LLD_BINARY``: path to the lld binary to check
 - ``LLDB_BINARY``: path to the lldb binary to check
 
@@ -59,6 +60,7 @@ Lit substitutions
     - ``%clangxx``
     - ``%clang-doc``
     - ``%clang-tidy``
+    - ``%FileCheck``
     - ``%lldb``
     - ``%lld``
     - ``%scan-build``

--- a/tests/clang-doc.cpp
+++ b/tests/clang-doc.cpp
@@ -3,7 +3,7 @@
 // formats to check that the correct log message is emitted for each format.
 
 // This test exists because in Fedora we packaged clang-doc but some assets were
-// missing. See https://issues.redhat.com/browse/LLVM-530
+// missing. See https://bugzilla.redhat.com/show_bug.cgi?id=2443053
 
 // RUN: %clang-doc --format=html --executor=standalone %s | FileCheck --check-prefix=HTML %s
 // RUN: %clang-doc --format=json --executor=standalone %s | FileCheck --check-prefix=JSON %s

--- a/tests/clang-doc.cpp
+++ b/tests/clang-doc.cpp
@@ -10,7 +10,6 @@
 // RUN: %clang-doc --format=md --executor=standalone %s | FileCheck --check-prefix=MD %s
 // RUN: %clang-doc --format=yaml --executor=standalone %s | FileCheck --check-prefix=YAML %s
 // REQUIRES: clang-doc
-// UNSUPPORTED: availability-clang-doc-missing
 
 int main(int argc, char** argv) {
         return 0;

--- a/tests/clang-doc.cpp
+++ b/tests/clang-doc.cpp
@@ -5,10 +5,10 @@
 // This test exists because in Fedora we packaged clang-doc but some assets were
 // missing. See https://bugzilla.redhat.com/show_bug.cgi?id=2443053
 
-// RUN: %clang-doc --format=html --executor=standalone %s | FileCheck --check-prefix=HTML %s
-// RUN: %clang-doc --format=json --executor=standalone %s | FileCheck --check-prefix=JSON %s
-// RUN: %clang-doc --format=md --executor=standalone %s | FileCheck --check-prefix=MD %s
-// RUN: %clang-doc --format=yaml --executor=standalone %s | FileCheck --check-prefix=YAML %s
+// RUN: %clang-doc --format=html --executor=standalone %s | %FileCheck --check-prefix=HTML %s
+// RUN: %clang-doc --format=json --executor=standalone %s | %FileCheck --check-prefix=JSON %s
+// RUN: %clang-doc --format=md --executor=standalone %s | %FileCheck --check-prefix=MD %s
+// RUN: %clang-doc --format=yaml --executor=standalone %s | %FileCheck --check-prefix=YAML %s
 // REQUIRES: clang-doc
 
 int main(int argc, char** argv) {

--- a/tests/clang-doc.cpp
+++ b/tests/clang-doc.cpp
@@ -10,6 +10,7 @@
 // RUN: %clang-doc --format=md --executor=standalone %s | FileCheck --check-prefix=MD %s
 // RUN: %clang-doc --format=yaml --executor=standalone %s | FileCheck --check-prefix=YAML %s
 // REQUIRES: clang-doc
+// UNSUPPORTED: availability-clang-doc-missing
 
 int main(int argc, char** argv) {
         return 0;

--- a/tests/clang-doc.cpp
+++ b/tests/clang-doc.cpp
@@ -1,0 +1,28 @@
+// Check that clang-doc can be executed in html format and that the output
+// contains the expected log messages. The test is executed for all supported
+// formats to check that the correct log message is emitted for each format.
+
+// This test exists because in Fedora we packaged clang-doc but some assets were
+// missing. See https://issues.redhat.com/browse/LLVM-530
+
+// RUN: %clang-doc --format=html --executor=standalone %s | FileCheck --check-prefix=HTML %s
+// RUN: %clang-doc --format=json --executor=standalone %s | FileCheck --check-prefix=JSON %s
+// RUN: %clang-doc --format=md --executor=standalone %s | FileCheck --check-prefix=MD %s
+// RUN: %clang-doc --format=yaml --executor=standalone %s | FileCheck --check-prefix=YAML %s
+// REQUIRES: clang-doc
+
+int main(int argc, char** argv) {
+        return 0;
+}
+
+// HTML: Emiting docs in html format.
+// JSON: Emiting docs in json format.
+// MD: Emiting docs in md format.
+// YAML: Emiting docs in yaml format.
+
+// CHECK-NEXT: Mapping decls...                          
+// CHECK-NEXT: Collecting infos...                       
+// CHECK-NEXT: Reducing 1 infos...                       
+// CHECK-NEXT: Generating docs...                        
+// CHECK-NEXT: Generating assets for docs...
+

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -75,9 +75,6 @@ def getLLVMMajorVersion():
 if "s390x" == "@CMAKE_HOST_SYSTEM_PROCESSOR@" and getLLVMMajorVersion() < 21:
    config.available_features.add("availability-compiler-rt-builtins-missing")
 
-if "@CLANG_DOC_BINARY@" == "CLANG_DOC_BINARY-NOTFOUND":
-    config.available_features.add("availability-clang-doc-missing")
-
 # This is necessary because LLVM 20 and earlier versions do build libunwind
 # on s390x even though the library is broken.
 if "s390x" == "@CMAKE_HOST_SYSTEM_PROCESSOR@" and getLLVMMajorVersion() < 22:

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -75,6 +75,9 @@ def getLLVMMajorVersion():
 if "s390x" == "@CMAKE_HOST_SYSTEM_PROCESSOR@" and getLLVMMajorVersion() < 21:
    config.available_features.add("availability-compiler-rt-builtins-missing")
 
+if "@CLANG_DOC_BINARY@" == "CLANG_DOC_BINARY-NOTFOUND":
+    config.available_features.add("availability-clang-doc-missing")
+
 # This is necessary because LLVM 20 and earlier versions do build libunwind
 # on s390x even though the library is broken.
 if "s390x" == "@CMAKE_HOST_SYSTEM_PROCESSOR@" and getLLVMMajorVersion() < 22:

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -27,6 +27,7 @@ def enable_library(name, library):
 # The order matters, e.g. substitution for clang-format-diff
 # must appear before clang-format, because the latter is a prefix of the former.
 
+enable_program('FileCheck', "@FILECHECK_BINARY@")
 enable_program('cc', "@CMAKE_C_COMPILER@")
 enable_program('cxx', "@CMAKE_CXX_COMPILER@")
 enable_program('clang-doc', "@CLANG_DOC_BINARY@")

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -29,6 +29,7 @@ def enable_library(name, library):
 
 enable_program('cc', "@CMAKE_C_COMPILER@")
 enable_program('cxx', "@CMAKE_CXX_COMPILER@")
+enable_program('clang-doc', "@CLANG_DOC_BINARY@")
 enable_program('clang-tidy', "@CLANG_TIDY_BINARY@")
 enable_program('clang-format-diff', "@CLANG_FORMAT_DIFF_BINARY@")
 enable_program('clang-format', "@CLANG_FORMAT_BINARY@")


### PR DESCRIPTION
This exists to address that `clang-doc` is packaged and default assets are not missing.

https://bugzilla.redhat.com/show_bug.cgi?id=2443053

I've tested this PR like so:

```console
$ LIT_FILTER="LLVM regression suite :: clang-doc.cpp" make check
-- Testing: 1 of 54 tests, 1 workers --
PASS: LLVM regression suite :: clang-doc.cpp (1 of 1)

Testing Time: 0.23s

Total Discovered Tests: 54
  Excluded: 53 (98.15%)
  Passed  :  1 (1.85%)
Built target check
```

In addition to checking `clang-doc`, this patch adds a `%FileCheck` substitution in LIT files and a `FILECHECK_BINARY` configuration option for CMake.


The failing fedora tests are actually correct because the [fix for Fedora](https://src.fedoraproject.org/rpms/llvm/pull-request/567) is not yet in:

```
******************** TEST 'LLVM regression suite :: clang-doc.cpp' FAILED ********************
Exit Code: 1

Command Output (stderr):
--
RUN: at line 8: /usr/bin/clang-doc --format=html --executor=standalone /__w/llvm-toolchain-integration-test-suite/llvm-toolchain-integration-test-suite/tests/clang-doc.cpp | FileCheck --check-prefix=HTML /__w/llvm-toolchain-integration-test-suite/llvm-toolchain-integration-test-suite/tests/clang-doc.cpp
+ /usr/bin/clang-doc --format=html --executor=standalone /__w/llvm-toolchain-integration-test-suite/llvm-toolchain-integration-test-suite/tests/clang-doc.cpp
+ FileCheck --check-prefix=HTML /__w/llvm-toolchain-integration-test-suite/llvm-toolchain-integration-test-suite/tests/clang-doc.cpp
Error while trying to load a compilation database:
Could not auto-detect compilation database for file "/__w/llvm-toolchain-integration-test-suite/llvm-toolchain-integration-test-suite/tests/clang-doc.cpp"
No compilation database found in /__w/llvm-toolchain-integration-test-suite/llvm-toolchain-integration-test-suite/tests or any parent directory
fixed-compilation-database: Error while opening fixed database: No such file or directory
json-compilation-database: Error while opening JSON database: No such file or directory
Running without flags.
error creating file clang-doc-default-stylesheet.css: No such file or directory
```