### PR TITLE
Update fedora versions

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fedora-version: [40, 41, rawhide]
+        fedora-version: [42, 43, 44, rawhide]
     container:
       image: "fedora:${{matrix.fedora-version}}"
       # These options are required to be able to run lldb inside the container


### PR DESCRIPTION
Fedora 40 and 41 are EOL. Test 42, 43 and 44 instead.