### PR TITLE
Use internal lit shell

### DIFF
--- a/tests/code_profiling.cpp
+++ b/tests/code_profiling.cpp
@@ -1,7 +1,7 @@
 // Test code coverage
 //
 // RUN: %clang -fprofile-instr-generate %s -o foo
-// RUN: LLVM_PROFILE_FILE="foo.profraw" ./foo
+// RUN: env LLVM_PROFILE_FILE="foo.profraw" ./foo
 // RUN: %llvm-profdata merge -output=foo.profdata foo.profraw
 // RUN: %clang -fprofile-instr-use=foo.profdata %s -o foo
 // RUN: ./foo

--- a/tests/hello.mlir
+++ b/tests/hello.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: clang, mlir-translate, llvm-config
-// RUN: %if llvm-14 %{ sed 's/func.func/func/' %s %} %else %{ cat %s %} | %mlir-translate --mlir-to-cpp > %t.c
+// RUN: %mlir-translate --mlir-to-cpp < %s > %t.c
 // RUN: %clang %t.c -o %t
 // RUN: %t
 

--- a/tests/hello.mlir
+++ b/tests/hello.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: clang, mlir-translate, llvm-config
-// RUN: if `%llvm-config --version | grep -qE '^14\.'`; then sed 's/func.func/func/' %s; else cat %s; fi | %mlir-translate --mlir-to-cpp > %t.c
+// RUN: %if llvm-14 %{ sed 's/func.func/func/' %s %} %else %{ cat %s %} | %mlir-translate --mlir-to-cpp > %t.c
 // RUN: %clang %t.c -o %t
 // RUN: %t
 

--- a/tests/libclang_cpp.cpp
+++ b/tests/libclang_cpp.cpp
@@ -20,10 +20,6 @@ int main(int argc, const char **argv) {
     // CommonOptionsParser constructor will parse arguments and create a
     // CompilationDatabase.  In case of error it will terminate the program.
 
-#if CLANG_VERSION_MAJOR < 13
-    clang::tooling::CommonOptionsParser OptionsParser(argc, argv,
-                                               MyToolCategory);
-#else
     auto ExpectedParser = CommonOptionsParser::create(argc, argv, MyToolCategory);
     if (!ExpectedParser) {
         // Fail gracefully for unsupported options.
@@ -31,7 +27,6 @@ int main(int argc, const char **argv) {
         return 1;
     }
     CommonOptionsParser& OptionsParser = ExpectedParser.get();
-#endif
 
     // Use OptionsParser.getCompilations() and OptionsParser.getSourcePathList()
     // to retrieve CompilationDatabase and the list of input file paths.

--- a/tests/libclang_cpp.cpp
+++ b/tests/libclang_cpp.cpp
@@ -1,10 +1,11 @@
 // Test the link against libclang-cppXX
 //
 // REQUIRES: llvm-config
-// RUN: %cxx  -DCLANG_MAJOR=`%llvm-config --version | cut -d . -f 1` -v %s -o %t `%llvm-config --cxxflags --ldflags --libs` -lclang-cpp
+// RUN: bash -c "%cxx -v %s -o %t `%llvm-config --cxxflags --ldflags --libs` -lclang-cpp"
 // RUN: ldd %t 2>&1 > %t.lddoutput
 // RUN: grep -q libclang-cpp %t.lddoutput
 
+#include "clang/Basic/Version.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "llvm/Support/CommandLine.h"
 
@@ -19,7 +20,7 @@ int main(int argc, const char **argv) {
     // CommonOptionsParser constructor will parse arguments and create a
     // CompilationDatabase.  In case of error it will terminate the program.
 
-#if CLANG_MAJOR < 13
+#if CLANG_VERSION_MAJOR < 13
     clang::tooling::CommonOptionsParser OptionsParser(argc, argv,
                                                MyToolCategory);
 #else

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -71,8 +71,6 @@ def getLLVMMajorVersion():
         raise BaseException("Could not parse LLVM version"
                             + out.stdout.decode('utf-8'))
 
-config.available_features.add("llvm-" + str(getLLVMMajorVersion()))
-
 if "s390x" == "@CMAKE_HOST_SYSTEM_PROCESSOR@" and getLLVMMajorVersion() < 21:
    config.available_features.add("availability-compiler-rt-builtins-missing")
 

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -4,7 +4,7 @@ import re
 import subprocess
 
 config.name = 'LLVM regression suite'
-config.test_format = lit.formats.ShTest(True)
+config.test_format = lit.formats.ShTest()
 config.suffixes = ['.ll', '.c', '.cpp', '.test', '.txt', '.s', '.mir', '.mlir']
 config.test_source_root = os.path.join("@CMAKE_CURRENT_SOURCE_DIR@", "tests")
 config.excludes = ['Inputs']
@@ -70,6 +70,8 @@ def getLLVMMajorVersion():
     else:
         raise BaseException("Could not parse LLVM version"
                             + out.stdout.decode('utf-8'))
+
+config.available_features.add("llvm-" + str(getLLVMMajorVersion()))
 
 if "s390x" == "@CMAKE_HOST_SYSTEM_PROCESSOR@" and getLLVMMajorVersion() < 21:
    config.available_features.add("availability-compiler-rt-builtins-missing")

--- a/tests/llvm_config_libs.cpp
+++ b/tests/llvm_config_libs.cpp
@@ -1,6 +1,6 @@
 // Test if llvm-config correctly finds headers and libs
-// RUN: %clangxx `%llvm-config --cxxflags --ldflags --libs` %s -o %t
-// RUN: %clangxx `%llvm-config  --link-shared --cxxflags --ldflags --libs` %s -o %t
+// RUN: bash -c "%clangxx `%llvm-config --cxxflags --ldflags --libs` %s -o %t"
+// RUN: bash -c "%clangxx `%llvm-config  --link-shared --cxxflags --ldflags --libs` %s -o %t"
 //
 // Check that warnings are not exported
 // RUN: %llvm-config --cxxflags | grep -v " \-W"

--- a/tests/lto_and_cross_dso_cfi.c
+++ b/tests/lto_and_cross_dso_cfi.c
@@ -3,7 +3,7 @@
 // RUN: mkdir %t.dir
 // RUN: %clang -UMAIN -flto -fsanitize=cfi -fsanitize-cfi-cross-dso -fvisibility=default -fuse-ld=lld %s -shared -o %t.dir/liblocalcrossdso.so
 // RUN: %clang -DMAIN -flto -fsanitize=cfi -fsanitize-cfi-cross-dso -fvisibility=default -fuse-ld=lld %s -o %t -L%t.dir -llocalcrossdso
-// RUN: LD_LIBRARY_PATH=%t.dir %t
+// RUN: env LD_LIBRARY_PATH=%t.dir %t
 // RUN: rm -f liblocalcrossdso.so
 // REQUIRES: clang, compiler-rt, lld
 // XFAIL: s390x, ppc64le, ppc64

--- a/tests/minimal_mlir_cmake.txt
+++ b/tests/minimal_mlir_cmake.txt
@@ -3,7 +3,7 @@
 # RUN: rm -rf %t
 # RUN: mkdir -p %t/_build
 # RUN: cat %s > %t/CMakeLists.txt
-# RUN: cd %t/_build && %cmake ..  -DMLIR_DIR=`%llvm-config --libdir`/cmake/mlir
+# RUN: cd %t/_build && bash -c "%cmake ..  -DMLIR_DIR=`%llvm-config --libdir`/cmake/mlir"
 
 cmake_minimum_required(VERSION 3.13.4)
 project(standalone-dialect LANGUAGES CXX C)

--- a/tests/openmp_tools.c
+++ b/tests/openmp_tools.c
@@ -1,7 +1,7 @@
 // Test OpenMP Tools support
 // RUN: %clang -fopenmp -DTOOLS %s -fPIC -shared -o %t_Tools.so
 // RUN: %clang -fopenmp -UTOOLS %s -o %t
-// RUN: OMP_TOOL_LIBRARIES=%t_Tools.so %t | grep "INIT"
+// RUN: env OMP_TOOL_LIBRARIES=%t_Tools.so %t | grep "INIT"
 // REQUIRES: clang, libomp
 #ifdef TOOLS
 

--- a/tests/plugins.cpp
+++ b/tests/plugins.cpp
@@ -1,4 +1,4 @@
-// RUN: %cxx `%llvm-config --cxxflags` -fPIC -shared %s -o Hello.so
+// RUN: bash -c "%cxx `%llvm-config --cxxflags` -fPIC -shared %s -o Hello.so"
 // RUN: %opt -load ./Hello.so -help | grep "Hello World Pass"
 // REQUIRES: opt, llvm-config
 

--- a/tests/plugins_newpm.txt
+++ b/tests/plugins_newpm.txt
@@ -4,7 +4,7 @@
 # RUN: cat %s > %t/CMakeLists.txt
 # RUN: cp %S/Inputs/llvm_newpm_pass.cpp %t
 # RUN: cd %t/_build
-# RUN: %cmake .. -DCMAKE_C_COMPILER=%cc -DCMAKE_CXX_COMPILER=%cxx -DLLVM_DIR=`%llvm-config --cmakedir`
+# RUN: bash -c "%cmake .. -DCMAKE_C_COMPILER=%cc -DCMAKE_CXX_COMPILER=%cxx -DLLVM_DIR=`%llvm-config --cmakedir`"
 # RUN: %cmake --build .
 # RUN: %clang -emit-llvm -O3 -c %S/Inputs/foo.c -o llvm-ir.bc
 # RUN: %opt -load-pass-plugin=./HelloPass.so -disable-output ./llvm-ir.bc  -passes=hellonewpm 2> %t.output

--- a/tests/scanbuild_missing_delete.cpp
+++ b/tests/scanbuild_missing_delete.cpp
@@ -2,7 +2,7 @@
 // REQUIRES: scan-build, scan-view
 // RUN: rm -rf %t.out && mkdir %t.out && cd %t.out && rm -rf *
 // RUN: %scan-build -o . %clangxx -c %s -o %t
-// RUN: %scan-view --no-browser * & WPID=$! && sleep 5 && kill $WPID
+// RUN: bash -c "%scan-view --no-browser * & WPID=$! && sleep 5 && kill $WPID"
 int main(int argc, char *argv[]) {
   while (argc--)
     new int();


### PR DESCRIPTION
Support for external shell is being removed and causes errors on LLVM 23.

This includes a number of changes to be compatible with the internal shell:

 * Use `env` when calling commands with an environment variable set.
 * Use `bash -c` when using command substitutions (backtick expressions). Unfortunately, these are not supported by the internal shell. It's possible to emulate them by writing the result of the command to a file and then using a `%{readfile:}` substitution -- but only since LLVM 22, which is not suitable for this repo. Another alternative I considered is to instead define a bunch of substitutions for llvm-config results in lit.cfg, but I feel like this kind of side-steps the intent of these tests. So I think just using explicit `bash -c` where necessary is our best bet.
 * Add an llvm-N feature so it can be tested with `%if` in one MLIR test.
 * Drop a custom CLANG_MAJOR define in one clang test, and just use the macro defined by Clang itself instead.
