### PR TITLE
Expect a PASS for lto_and_cfi on LLVM 24

### DIFF
--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -78,3 +78,9 @@ if "s390x" == "@CMAKE_HOST_SYSTEM_PROCESSOR@" and getLLVMMajorVersion() < 21:
 # on s390x even though the library is broken.
 if "s390x" == "@CMAKE_HOST_SYSTEM_PROCESSOR@" and getLLVMMajorVersion() < 22:
    config.available_features.add("availability-libunwind-missing")
+
+if getLLVMMajorVersion() < 24 and \
+   ("s390x" == "@CMAKE_HOST_SYSTEM_PROCESSOR@"
+    or "ppc64le" == "@CMAKE_HOST_SYSTEM_PROCESSOR@"
+    or "ppc64" == "@CMAKE_HOST_SYSTEM_PROCESSOR@"):
+   config.available_features.add("availability-lto-cfi-missing")

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -63,7 +63,7 @@ enable_feature("float16", "@ENABLE_FLOAT16@")
 enable_feature("gold", "@ENABLE_GOLD_TESTS@")
 
 def getLLVMMajorVersion():
-    out = subprocess.run(["llvm-config", "--version"], capture_output=True)
+    out = subprocess.run(["@LLVMCONFIG_BINARY@", "--version"], capture_output=True)
     m = re.match(r'^([0-9]+).', out.stdout.decode('utf-8'))
     if m:
         return int(m.group(1))

--- a/tests/lto_and_cfi.c
+++ b/tests/lto_and_cfi.c
@@ -1,7 +1,7 @@
 // Test compatibility between lto and CFI, see  https://bugzilla.redhat.com/show_bug.cgi?id=1794936
 // RUN: %clang -flto -fsanitize=cfi -fvisibility=hidden %s -o %t
 // REQUIRES: clang, compiler-rt
-// XFAIL: s390x, ppc64le, ppc64
+// XFAIL: availability-lto-cfi-missing
 
 int main() {
   return 0;


### PR DESCRIPTION
A recent change in LLVM 24 caused this test to PASS on s390x, ppc64le and ppc64.
So, mark this test as XFAIL for these architectures only on LLVM < 24.