### PR TITLE
Use RequiredPassInfoMixin on LLVM 24

### DIFF
--- a/tests/Inputs/llvm_newpm_pass.cpp
+++ b/tests/Inputs/llvm_newpm_pass.cpp
@@ -22,11 +22,18 @@
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
+#if LLVM_VERSION_MAJOR >= 24
+class HelloWorldNewPMPass : public RequiredPassInfoMixin<HelloWorldNewPMPass> {
+public:
+    PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+};
+#else
 class HelloWorldNewPMPass : public PassInfoMixin<HelloWorldNewPMPass> {
 public:
     PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
     static bool isRequired() { return true; }
 };
+#endif
 
 PreservedAnalyses HelloWorldNewPMPass::run(
         Function &F,


### PR DESCRIPTION
This is the new style for declaring a required pass. The old PassInfoMixin was moved into the detail namespace in: https://github.com/llvm/llvm-project/commit/80a1e2125c7ec7db402925d153c0dbd6041d3004